### PR TITLE
Feat: Log execution failures

### DIFF
--- a/internal/history/history_test.go
+++ b/internal/history/history_test.go
@@ -21,14 +21,18 @@ func TestWriteHistory(t *testing.T) {
 		LockDir: "/tmp",
 	}
 
-	writeFunc, err := WriteHistory(mockFS, cfg, filePath, maxLines, nil)
+	historyWriter, err := NewHistoryWriter(mockFS, cfg, filePath, nil)
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
 
+	historyWriter.MarkExecutionEnd()
+
 	time.Sleep(1 * time.Second) // Simulate some duration
 
-	err = writeFunc()
+	historyWriter.MarkExecutionEnd()
+
+	err = historyWriter.WriteHistory(nil)
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}


### PR DESCRIPTION
Refactored the history writer into a new interface. This allows us to track attempted start to execution start to execution end and get the duration of execution as well as any failures to execute